### PR TITLE
Suggested changes to this template

### DIFF
--- a/templates/mvp1-templates/mvp1-template4-bte-aeolus/mvp1-template4-bte-aeolus.json
+++ b/templates/mvp1-templates/mvp1-template4-bte-aeolus/mvp1-template4-bte-aeolus.json
@@ -20,7 +20,7 @@
                         {
                          "id": "biolink:evidence_count",   
                          "operator": ">",
-                         "value": "20"            
+                         "value": 20            
                         }
                     ]
                 }

--- a/templates/mvp1-templates/mvp1-template4-bte-aeolus/mvp1-template4-bte-aeolus.json
+++ b/templates/mvp1-templates/mvp1-template4-bte-aeolus/mvp1-template4-bte-aeolus.json
@@ -3,7 +3,7 @@
         {
             "id": "lookup",
             "runner_parameters": {
-                "allowlist": ["infores:biothings-explorer"]  
+                "allowlist": ["infores:service-provider-trapi"]  
             }
         }
     ],

--- a/templates/mvp1-templates/mvp1-template4-bte-aeolus/mvp1-template5-service-provider-aeolus.json
+++ b/templates/mvp1-templates/mvp1-template4-bte-aeolus/mvp1-template5-service-provider-aeolus.json
@@ -1,10 +1,13 @@
 {
-    "workflow": [                                             
+    "workflow": [
         {
             "id": "lookup",
             "runner_parameters": {
-                "allowlist": ["infores:service-provider-trapi"]  
+                "allowlist": ["infores:service-provider-trapi"]
             }
+        },
+        {
+            "id":"score"
         }
     ],
     "message": {


### PR DESCRIPTION
@karafecho 

I have two suggestions/questions for this template:
* perhaps the CQS should use [Service-Provider-TRAPI](http://smart-api.info/registry?q=36f82f05705c317bac17ddae3a0ea2f0) which is a KP, rather than BTE which is an ARA? Service-Provider-TRAPI will also return faster (working off of a smaller set of underlying KPs). However, it won't score the results returned. 
* the attribute-constraint value should be an int (number) rather than a string? A string doesn't seem to make sense with the ">" operator 

And @mbrush: I don't have an objection to using "biolink:evidence_count" for the attribute-type-id. But I am confused on why we use it over ["biolink:has_count"](https://github.com/biolink/biolink-model/blob/dc87efcf374cd80a462d62a9087978bee1e73a4c/biolink-model.yaml#L817) or ["biolink:concept_pair_count"](https://github.com/biolink/biolink-model/blob/dc87efcf374cd80a462d62a9087978bee1e73a4c/biolink-model.yaml#L5711).