### PR TITLE
TMKP MVP1 CQS Template

### DIFF
--- a/templates/mvp1-templates/mvp1-template5-service-provider-tmkp-targeted/README.md
+++ b/templates/mvp1-templates/mvp1-template5-service-provider-tmkp-targeted/README.md
@@ -1,0 +1,13 @@
+## Description
+
+This CQS template is designed to capture `chemical - biolink:treats_or_applied_or_studied_to_treat - disease_or_phenotypic_feature` assertions that are sourced in the Text Mining Targeted KP.
+
+Caveats:
+* The Workflow Runner cannot query the TMKP Targeted KG directly. It queries the general Service Provider end point in order to retrieve TMKP Targeted assertions. The current template is not constrained to TMKP results specifically, so it could possibly return results from other Service Provider services.
+* The template requires at least 5 evidence sentences to support an assertion in order for it to be included in the result set.
+
+
+## Testing
+
+The following assertion exists in the TMKP Targeted Assertion KG:
+`DRUGBANK:DB15223 (Flotetuzumab) -- biolink:treats_or_applied_or_studied_to_treat --> MONDO:0018874 (acute myeloid leukemia)`

--- a/templates/mvp1-templates/mvp1-template5-service-provider-tmkp-targeted/mvp1-template5-service-provider-tmkp-targeted.json
+++ b/templates/mvp1-templates/mvp1-template5-service-provider-tmkp-targeted/mvp1-template5-service-provider-tmkp-targeted.json
@@ -16,15 +16,7 @@
         "e0": {
           "predicates": ["biolink:treats_or_applied_or_studied_to_treat"],
           "subject": "n0",
-          "object": "n1",
-          "attribute_constraints": [
-            {
-              "name": "publication count threshold",
-              "id": "biolink:evidence_count",
-              "operator": ">",
-              "value": 5
-            }
-          ]
+          "object": "n1"
         }
       },
       "nodes": {

--- a/templates/mvp1-templates/mvp1-template5-service-provider-tmkp-targeted/mvp1-template5-service-provider-tmkp-targeted.json
+++ b/templates/mvp1-templates/mvp1-template5-service-provider-tmkp-targeted/mvp1-template5-service-provider-tmkp-targeted.json
@@ -1,0 +1,43 @@
+{
+  "workflow": [
+    {
+      "id": "lookup",
+      "runner_parameters": {
+        "allowlist": ["infores:service-provider-trapi"]
+      }
+    },
+    {
+      "id": "score"
+    }
+  ],
+  "message": {
+    "query_graph": {
+      "edges": {
+        "e0": {
+          "predicates": ["biolink:treats_or_applied_or_studied_to_treat"],
+          "subject": "n0",
+          "object": "n1",
+          "attribute_constraints": [
+            {
+              "name": "publication count threshold",
+              "id": "biolink:evidence_count",
+              "operator": ">",
+              "value": 5
+            }
+          ]
+        }
+      },
+      "nodes": {
+        "n0": {
+          "categories": ["biolink:ChemicalEntity"],
+          "is_set": false
+        },
+        "n1": {
+          "categories": ["biolink:DiseaseOrPhenotypicFeature"],
+          "ids": ["MONDO:0000000"],
+          "is_set": false
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Hi all,

This PR contains a provisional MVP1 CQS Template for the TMKP targeted assertion KG. I've modeled the template after the [Service Provider / BTE AEOLUS template](https://github.com/TranslatorSRI/CQS/blob/main/templates/mvp1-templates/mvp1-template4-bte-aeolus/mvp1-template5-service-provider-aeolus.json).

This template should be considered a **work-in-progress** as there are some caveats:

  1. The Workflow Runner cannot query the TMKP KG directly (as I understand it) because it is hosted by Service Provider, so this provisional workflow is set up to access the Service Provider end point. I had hoped to use the `primary knowledge source` edge attribute to constrain results to be from TMKP, however, I have been unable to successfully run a query with attribute constraints against the Service Provider end point. There is a thread in the BTE Slack channel inquiring about this issue.

  2. I have been unable to get results back from the Workflow Runner using the template as input and the test curies that are provided in the README. I have validated that the test curies are in the KG, and do return in results when querying the Service Provider end point directly (as long as there are no attribute constraints). The same query run through the Workflow Runner does not seem to return results, and I am unsure how to diagnose the issue. **Any suggestions/help with debugging queries when run through the Workflow Runner would be greatly appreciated. Thanks!**
  