### PR TITLE
Create mvp1-template11-multiomics-ctkp.json

### DIFF
--- a/templates/mvp1-templates/mvp-template11-multiomics-ctkp/mvp1-template11-multiomics-ctkp.json
+++ b/templates/mvp1-templates/mvp-template11-multiomics-ctkp/mvp1-template11-multiomics-ctkp.json
@@ -23,14 +23,10 @@
           ],
           "attribute_constraints": [
             {
-              "id": "biolink:max_research_phase",
-              "name": "clinical-trials-phase",
+              "id": "elevate_to_prediction",
+              "name": "boolean_make_prediction_constraint",
               "operator": "==",
-              "value": [
-                "clinical_trial_phase_1",
-                "clinical_trial_phase_2",
-                "clinical_trial_phase_3"
-              ]
+              "value": "True"
             }
           ]
         }

--- a/templates/mvp1-templates/mvp-template11-multiomics-ctkp/mvp1-template11-multiomics-ctkp.json
+++ b/templates/mvp1-templates/mvp-template11-multiomics-ctkp/mvp1-template11-multiomics-ctkp.json
@@ -1,0 +1,69 @@
+{
+  "workflow": [
+    {
+      "id": "lookup",
+      "runner_parameters": {
+        "allowlist": [
+          "infores:multiomics-clinicaltrials"
+        ]
+      }
+    },
+    {
+      "id": "score"
+    }
+  ],
+  "message": {
+    "query_graph": {
+      "edges": {
+        "e00": {
+          "subject": "n00",
+          "object": "n01",
+          "predicates": [
+            "biolink:in_clinical_trials_for"
+          ],
+          "attribute_constraints": [
+            {
+              "id": "biolink:max_research_phase",
+              "name": "clinical-trials-phase",
+              "operator": "==",
+              "value": [
+                "clinical_trial_phase_1",
+                "clinical_trial_phase_2",
+                "clinical_trial_phase_3"
+              ]
+            }
+          ]
+        }
+      },
+      "nodes": {
+        "n00": {
+          "categories": [
+            "biolink:ChemicalEntity"
+          ]
+        },
+        "n01": {
+          "categories": [
+            "biolink:DiseaseOrPhenotypicFeature"
+          ],
+          "ids": []
+        }
+      }
+    }
+  },
+  "cqs": {
+    "results_limit": null,
+    "edge_sources": [
+      {
+        "resource_id": "infores:cqs",
+        "resource_role": "primary_knowledge_source"
+      },
+      {
+        "resource_id": "infores:multiomics-clinicaltrials",
+        "resource_role": "supporting_data_source"
+      }
+    ],
+    "attribute_type_ids": [
+      "biolink:max_research_phase"
+    ]
+  }
+}


### PR DESCRIPTION
Adding mvp1 template to support ctkp-based treats predictions  (so that we can eventually remove chembl-based templates)