### PR TITLE
Create mvp-template-12-multiomics-drugapprovals-faers.json

### DIFF
--- a/templates/mvp1-templates/mvp-template-12-multiomics-drugapprovals-faers/mvp-template-12-multiomics-drugapprovals-faers.json
+++ b/templates/mvp1-templates/mvp-template-12-multiomics-drugapprovals-faers/mvp-template-12-multiomics-drugapprovals-faers.json
@@ -1,0 +1,62 @@
+{
+  "workflow": [
+    {
+      "id": "lookup",
+      "runner_parameters": {
+        "allowlist": [
+          "infores:multiomics-drugapprovals"
+        ]
+      }
+    },
+    {
+      "id": "score"
+    }
+  ],
+  "message": {
+    "query_graph": {
+      "edges": {
+        "e0": {
+          "predicates": [
+            "biolink:applied_to_treat"
+          ],
+          "subject": "n0",
+          "object": "n1",
+          "attribute_constraints": [
+            {
+              "name": "evidence_count_constraint",
+              "id": "biolink:evidence_count",
+              "operator": ">",
+              "value": 10
+            }
+          ]
+        }
+      },
+      "nodes": {
+        "n0": {
+          "categories": [
+            "biolink:ChemicalEntity"
+          ]
+        },
+        "n1": {
+          "categories": [
+            "biolink:DiseaseOrPhenotypicFeature"
+          ],
+          "ids": []
+        }
+      }
+    }
+  },
+  "cqs": {
+    "results_limit": 5.6,
+    "edge_sources": [
+      {
+        "resource_id": "infores:cqs",
+        "resource_role": "primary_knowledge_source"
+      },
+      {
+        "resource_id": "infores:multiomics-drugapprovals",
+        "resource_role": "supporting_data_source"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
Adding new template for faers-based treats predictions from edges in the multiomics drug-approvals kp (to replace the current aeolus-baed template). 